### PR TITLE
ADD deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Nekobito is a browser-based markdown editor.
 ![screenshot of Nekobito](nekobito_screen.png)
 
 ## DEPRECATION WARNING
-https://nekobito.github.io is no longer maintained, use https://nekobito.netlify.com
+https://nekobito.github.io is no longer maintained, use https://nekobito.netlify.app
 
 ## Usage
 * Open https://nekobito.netlify.com

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Nekobito is a browser-based markdown editor.
 
 ![screenshot of Nekobito](nekobito_screen.png)
 
+## DEPRECATION WARNING
+https://nekobito.github.io is no longer maintained, use https://nekobito.netlify.com
+
 ## Usage
 * Open https://nekobito.netlify.com
 * Write markdown.


### PR DESCRIPTION
## Summary
Add Deprecation warning to give notice that github.io version has not been maintained.
github.io version has some bugs, these have been fixed in the latest netlify versions but some users still use it.
So I suggest announcing it through README.
